### PR TITLE
Allow blocks to be passable

### DIFF
--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
@@ -25,6 +25,7 @@ import net.minecraftforge.fml.relauncher.SideOnly;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
@@ -151,5 +152,20 @@ public class BlockContent extends BlockBase {
         return Optional.ofNullable(blockRepresentation.getMobilityFlag())
                 .map(PushReaction::getInternal)
                 .orElse(state.getMobilityFlag());
+    }
+
+    @Override
+    public boolean isPassable(IBlockAccess worldIn, BlockPos pos) {
+        return this.blockRepresentation.isPassable();
+    }
+
+    @Override
+    public void addCollisionBoxToList(IBlockState state, World worldIn, BlockPos pos, AxisAlignedBB entityBox,
+                                      List<AxisAlignedBB> collidingBoxes, Entity entityIn, boolean isActualState) {
+        if (this.blockRepresentation.isPassable()) {
+            addCollisionBoxToList(pos, entityBox, collidingBoxes, NULL_AABB);
+        } else {
+            addCollisionBoxToList(pos, entityBox, collidingBoxes, state.getCollisionBoundingBox(worldIn, pos));
+        }
     }
 }

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
@@ -69,6 +69,8 @@ public class BlockRepresentation implements IRepresentation<Block> {
     public IBlockAction onRandomTick;
     @ZenProperty
     public PushReaction mobilityFlag;
+    @ZenProperty
+    public boolean passable = !this.blockMaterial.blocksMovement();
 
     @ZenMethod
     public String getUnlocalizedName() {
@@ -290,6 +292,16 @@ public class BlockRepresentation implements IRepresentation<Block> {
         this.mobilityFlag = mobilityFlag;
     }
 
+    @ZenMethod
+    public boolean isPassable() {
+        return passable;
+    }
+
+    @ZenMethod
+    public void setPassable(boolean passable) {
+        this.passable = passable;
+    }
+
     @Override
     public Block getInternal() {
         return ContentTweaker.instance.getRegistry(BlockRegistry.class, "BLOCK").get(new ResourceLocation(
@@ -310,6 +322,4 @@ public class BlockRepresentation implements IRepresentation<Block> {
     public void register() {
         ContentTweaker.instance.getRegistry(BlockRegistry.class, "BLOCK").register(new BlockContent(this));
     }
-
-
 }


### PR DESCRIPTION
There was no way around it but using a depreciated function it seems...

Closes The-Acronym-Coders/ContentTweaker#59