### PR TITLE
Food Items

### DIFF
--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/food/ItemContentFood.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/food/ItemContentFood.java
@@ -120,22 +120,6 @@ public class ItemContentFood extends ItemFood implements IHasModel, IHasGenerate
 
     @Override
     @Nonnull
-    @ParametersAreNonnullByDefault
-    public ActionResult<ItemStack> onItemRightClick(World world, EntityPlayer player, EnumHand hand) {
-        EnumActionResult enumActionResult = EnumActionResult.PASS;
-        ItemStack itemStack = player.getHeldItem(hand);
-        if (itemRepresentation.getItemRightClick() != null) {
-            String stringResult = itemRepresentation.getItemRightClick().onRightClick(new MCItemStack(itemStack),
-                    new MCWorld(world), new MCPlayer(player), hand.name());
-            if (stringResult != null) {
-                enumActionResult = EnumActionResult.valueOf(stringResult.toUpperCase(Locale.US));
-            }
-        }
-        return new ActionResult<>(enumActionResult, itemStack);
-    }
-
-    @Override
-    @Nonnull
     public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing,
                                       float hitX, float hitY, float hitZ) {
         EnumActionResult actionResult = EnumActionResult.PASS;

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/food/ItemFoodRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/food/ItemFoodRepresentation.java
@@ -3,6 +3,7 @@ package com.teamacronymcoders.contenttweaker.modules.vanilla.items.food;
 import com.teamacronymcoders.base.registrysystem.ItemRegistry;
 import com.teamacronymcoders.contenttweaker.ContentTweaker;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.items.ItemRepresentation;
+import net.minecraft.item.EnumAction;
 import stanhebben.zenscript.annotations.ZenClass;
 import stanhebben.zenscript.annotations.ZenMethod;
 import stanhebben.zenscript.annotations.ZenProperty;
@@ -17,6 +18,8 @@ public class ItemFoodRepresentation extends ItemRepresentation {
     public boolean wolfFood = false;
     @ZenProperty
     public float saturation = 0.6f;
+    @ZenProperty
+    public String itemUseAction = EnumAction.EAT.toString();
 
     @ZenMethod
     public int getHealAmount() {
@@ -56,6 +59,16 @@ public class ItemFoodRepresentation extends ItemRepresentation {
     @ZenMethod
     public void setSaturation(float saturation) {
         this.saturation = saturation;
+    }
+
+    @ZenMethod
+    public String getItemUseAction() {
+        return itemUseAction;
+    }
+
+    @ZenMethod
+    public void setItemUseAction(String itemUseAction) {
+        this.itemUseAction = itemUseAction;
     }
 
     @Override

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/food/ItemFoodRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/food/ItemFoodRepresentation.java
@@ -10,6 +10,11 @@ import stanhebben.zenscript.annotations.ZenProperty;
 
 @ZenClass("mods.contenttweaker.ItemFood")
 public class ItemFoodRepresentation extends ItemRepresentation {
+    public ItemFoodRepresentation() {
+        super();
+        this.itemUseAction = EnumAction.EAT.toString();
+    }
+
     @ZenProperty
     public int healAmount;
     @ZenProperty
@@ -18,8 +23,6 @@ public class ItemFoodRepresentation extends ItemRepresentation {
     public boolean wolfFood = false;
     @ZenProperty
     public float saturation = 0.6f;
-    @ZenProperty
-    public String itemUseAction = EnumAction.EAT.toString();
 
     @ZenMethod
     public int getHealAmount() {
@@ -59,16 +62,6 @@ public class ItemFoodRepresentation extends ItemRepresentation {
     @ZenMethod
     public void setSaturation(float saturation) {
         this.saturation = saturation;
-    }
-
-    @ZenMethod
-    public String getItemUseAction() {
-        return itemUseAction;
-    }
-
-    @ZenMethod
-    public void setItemUseAction(String itemUseAction) {
-        this.itemUseAction = itemUseAction;
     }
 
     @Override


### PR DESCRIPTION
Finishing up work on the food items.

I'm unsure if removing the override is the right direction, or if I should keep it, and just add
```Java
if (player.canEat(this.itemRepresentation.isAlwaysEditable())) {
    player.setActiveHand(hand);
    return new ActionResult<ItemStack>(EnumActionResult.SUCCESS, itemstack);
}
```
(the default behavior for `FoodItem`) before the custom function check. This would enable the custom function to still work as long as the player cant eat and the food is not always editable.
