### PR TITLE
Block coloring support and compile error fix

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ mod_version=4.8.0
 
 base_version=3.11.0
 chickens_version=6.0.2
-crafttweaker_version=4.1.6.465
+crafttweaker_version=4.1.12.507
 mantle_version=1.3.1.+
 tinkers_version=2.9.0.+
 jei_version = jei_1.12.2:4.8.5.+

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
@@ -6,9 +6,13 @@ import com.teamacronymcoders.contenttweaker.api.IRepresentation;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.aabb.MCAxisAlignedBB;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockmaterial.BlockMaterialDefinition;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockmaterial.IBlockMaterialDefinition;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.color.CTColor;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.PushReaction;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.resourcelocation.CTResourceLocation;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockAction;
+import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockColorSupplier;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockDropHandler;
+import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IItemColorSupplier;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.items.ICreativeTab;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.resources.creativetab.MCCreativeTab;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.resources.sounds.ISoundTypeDefinition;
@@ -81,6 +85,12 @@ public class BlockRepresentation implements IRepresentation<Block> {
     public boolean beaconBase = false;
     @ZenProperty
     public TileEntityRepresentation tileEntityRepresentation = null;
+    @ZenProperty
+    public IBlockColorSupplier blockColorSupplier = (state, access, pos, tint) -> CTColor.fromInt(-1);
+    @ZenProperty
+    public IItemColorSupplier itemColorSupplier = (itemStack, tint) -> CTColor.fromInt(-1);
+    @ZenProperty
+    public CTResourceLocation textureLocation;
 
     @ZenMethod
     public String getUnlocalizedName() {
@@ -330,6 +340,36 @@ public class BlockRepresentation implements IRepresentation<Block> {
     @ZenMethod
     public void setDropHandler(IBlockDropHandler dropHandler) {
         this.dropHandler = dropHandler;
+    }
+
+    @ZenMethod
+    public IBlockColorSupplier getBlockColorSupplier() {
+        return blockColorSupplier;
+    }
+
+    @ZenMethod
+    public void setBlockColorSupplier(IBlockColorSupplier blockColorSupplier) {
+        this.blockColorSupplier = blockColorSupplier;
+    }
+
+    @ZenMethod
+    public IItemColorSupplier getItemColorSupplier() {
+        return itemColorSupplier;
+    }
+
+    @ZenMethod
+    public void setItemColorSupplier(IItemColorSupplier itemColorSupplier) {
+        this.itemColorSupplier = itemColorSupplier;
+    }
+
+    @ZenMethod
+    public CTResourceLocation getTextureLocation() {
+        return textureLocation;
+    }
+
+    @ZenMethod
+    public void setTextureLocation(CTResourceLocation resourceLocation) {
+        this.textureLocation = resourceLocation;
     }
 
     @Override

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/functions/IBlockColorSupplier.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/functions/IBlockColorSupplier.java
@@ -1,0 +1,14 @@
+package com.teamacronymcoders.contenttweaker.modules.vanilla.functions;
+
+import com.teamacronymcoders.contenttweaker.api.ctobjects.blockpos.IBlockPos;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.blockstate.ICTBlockState;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.color.CTColor;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.world.IBlockAccess;
+import stanhebben.zenscript.annotations.ZenClass;
+
+@ZenRegister
+@ZenClass("mods.contenttweaker.IBlockColorSupplier")
+public interface IBlockColorSupplier {
+    CTColor getColor(ICTBlockState state, IBlockAccess access, IBlockPos pos, int tintIndex);
+}

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemContent.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemContent.java
@@ -15,6 +15,7 @@ import com.teamacronymcoders.base.util.files.templates.TemplateManager;
 import com.teamacronymcoders.contenttweaker.api.MissingFieldsException;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockpos.MCBlockPos;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockstate.MCBlockState;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.color.CTColor;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.entity.EntityHelper;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.entity.player.CTPlayer;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.Facing;
@@ -230,7 +231,10 @@ public class ItemContent extends ItemBase implements IHasModel, IHasGeneratedMod
 
     @Override
     public int getColorFromItemstack(@Nonnull ItemStack stack, int tintIndex) {
-        return itemRepresentation.getItemColorSupplier().getColor(new MCItemStack(stack), tintIndex).getIntColor();
+        return Optional.ofNullable(itemRepresentation.getItemColorSupplier())
+                .map(supplier -> supplier.getColor(new MCItemStack(stack), tintIndex))
+                .map(CTColor::getIntColor)
+                .orElse(-1);
     }
 
     @Override


### PR DESCRIPTION
Added IBlockColorSupplier (#130 ) to allow for coloring custom blocks.

Block representation now also includes an itemColorSupplier in addition to the new blockColorSupplier to allow for coloring the ItemBlock.

Example of translucent colored blocks, https://gyazo.com/0998fbc8851fd773922ccf6b746434b7