### PR TITLE
Allow for blocks to be affected by gravity

### DIFF
--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
@@ -14,10 +14,12 @@ import crafttweaker.api.minecraft.CraftTweakerMC;
 import crafttweaker.mc1120.item.MCItemStack;
 import crafttweaker.mc1120.world.MCBlockAccess;
 import net.minecraft.block.Block;
+import net.minecraft.block.BlockFalling;
 import net.minecraft.block.material.EnumPushReaction;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
+import net.minecraft.entity.item.EntityFallingBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.BlockRenderLayer;
@@ -120,6 +122,9 @@ public class BlockContent extends BlockBase {
     public void onBlockAdded(@Nonnull World world, @Nonnull BlockPos pos, @Nonnull IBlockState state) {
         super.onBlockAdded(world, pos, state);
         activateBlockAction(this.blockRepresentation.getOnBlockPlace(), world, pos, state);
+        if (this.blockRepresentation.hasGravity()) {
+            world.scheduleUpdate(pos, this, tickRate(world));
+        }
     }
 
     @Override
@@ -150,6 +155,25 @@ public class BlockContent extends BlockBase {
     @Override
     public void updateTick(World world, BlockPos pos, IBlockState state, Random rand) {
         activateBlockAction(this.blockRepresentation.getOnUpdateTick(), world, pos, state);
+        if (this.blockRepresentation.hasGravity() && !world.isRemote && (world.isAirBlock(pos.down()) || BlockFalling.canFallThrough(world.getBlockState(pos.down()))) &&
+                pos.getY() >= 0 && world.isAreaLoaded(pos.add(-32, -32, -32), pos.add(32, 32, 32))) {
+            world.spawnEntity(new EntityFallingBlock(world, (double) pos.getX() + 0.5D, (double) pos.getY(), (double) pos.getZ() + 0.5D, world.getBlockState(pos)));
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public void neighborChanged(IBlockState state, World world, BlockPos pos, Block blockIn, BlockPos fromPos) {
+        if (this.blockRepresentation.hasGravity()) {
+            world.scheduleUpdate(pos, this, tickRate(world));
+        } else {
+            super.neighborChanged(state, world, pos, blockIn, fromPos);
+        }
+    }
+
+    @Override
+    public int tickRate(World world) {
+        return this.blockRepresentation.hasGravity() ? 2 : super.tickRate(world);
     }
 
     public void activateBlockAction(IBlockAction blockAction, World world, BlockPos blockPos, IBlockState blockState) {

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
@@ -34,6 +34,8 @@ public class BlockRepresentation implements IRepresentation<Block> {
     @ZenProperty
     public boolean fullBlock = true;
     @ZenProperty
+    public boolean gravity = false;
+    @ZenProperty
     public int lightOpacity = 255;
     @ZenProperty
     public boolean translucent = false;
@@ -110,6 +112,16 @@ public class BlockRepresentation implements IRepresentation<Block> {
     @ZenMethod
     public void setFullBlock(boolean fullBlock) {
         this.fullBlock = fullBlock;
+    }
+
+    @ZenMethod
+    public boolean hasGravity() {
+        return gravity;
+    }
+
+    @ZenMethod
+    public void setHasGravity(boolean gravity) {
+        this.gravity = gravity;
     }
 
     @ZenMethod


### PR DESCRIPTION
There are three event styled methods that have to do with falling blocks I did not implement.

The first which I can implement but didn't is `onStartFalling(EntityFallingBlock fallingEntity)` as I couldn't see a use for it and was not quite sure if I would need to implement a new wrapper for EntityFallingBlock.

The two that I could not implement as this does not directly extend BlockFalling are:
```
public void onEndFalling(World worldIn, BlockPos pos, IBlockState fallingState, IBlockState hitState)
public void onBroken(World worldIn, BlockPos pos)
```

These methods get called by EntityFallingBlock but have no default implementation in blocks like BlockSand so gravity still works properly just does not allow for users to have custom things happen when the falling block lands.