### PR TITLE
Add support for BlockFaceShape

### DIFF
--- a/src/main/java/com/teamacronymcoders/contenttweaker/api/ctobjects/enums/FaceShape.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/api/ctobjects/enums/FaceShape.java
@@ -1,0 +1,78 @@
+package com.teamacronymcoders.contenttweaker.api.ctobjects.enums;
+
+import com.teamacronymcoders.contenttweaker.api.ICTObject;
+import crafttweaker.annotations.ZenRegister;
+import net.minecraft.block.state.BlockFaceShape;
+import stanhebben.zenscript.annotations.OperatorType;
+import stanhebben.zenscript.annotations.ZenClass;
+import stanhebben.zenscript.annotations.ZenMethod;
+import stanhebben.zenscript.annotations.ZenOperator;
+
+@ZenRegister
+@ZenClass("mods.contenttweaker.FaceShape")
+public class FaceShape implements ICTObject<BlockFaceShape> {
+    private BlockFaceShape faceShape;
+
+    private FaceShape(BlockFaceShape blockFaceShape) {
+        this.faceShape = blockFaceShape;
+    }
+
+    public static FaceShape of(BlockFaceShape blockFaceShape) {
+        return new FaceShape(blockFaceShape);
+    }
+
+    @ZenOperator(OperatorType.COMPARE)
+    public int compare(FaceShape other) {
+        return this.getInternal().compareTo(other.getInternal());
+    }
+
+    @ZenMethod
+    public static FaceShape solid() {
+        return new FaceShape(BlockFaceShape.SOLID);
+    }
+
+    @ZenMethod
+    public static FaceShape bowl() {
+        return  new FaceShape(BlockFaceShape.BOWL);
+    }
+
+    @ZenMethod
+    public static FaceShape center_small() {
+        return new FaceShape(BlockFaceShape.CENTER_SMALL);
+    }
+
+    @ZenMethod
+    public static FaceShape middle_pole_thin() {
+        return new FaceShape(BlockFaceShape.MIDDLE_POLE_THIN);
+    }
+
+    @ZenMethod
+    public static FaceShape center() {
+        return new FaceShape(BlockFaceShape.CENTER);
+    }
+
+    @ZenMethod
+    public static FaceShape middle_pole() {
+        return new FaceShape(BlockFaceShape.MIDDLE_POLE);
+    }
+
+    @ZenMethod
+    public static FaceShape center_big() {
+        return new FaceShape(BlockFaceShape.CENTER_BIG);
+    }
+
+    @ZenMethod
+    public static FaceShape middle_pole_thick() {
+        return new FaceShape(BlockFaceShape.MIDDLE_POLE_THICK);
+    }
+
+    @ZenMethod
+    public static FaceShape undefined() {
+        return new FaceShape(BlockFaceShape.UNDEFINED);
+    }
+
+    @Override
+    public BlockFaceShape getInternal() {
+        return this.faceShape;
+    }
+}

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
@@ -362,7 +362,8 @@ public class BlockContent extends BlockBase implements IHasBlockColor, IHasItemC
             blockAccess = new MCBlockAccess(world);
         }
         IBlockPos blockPos = pos == null ? null : new MCBlockPos(pos);
-        FaceShape faceShape = blockFaceSupplier.getBlockFaceShape(blockAccess, new MCBlockState(state), blockPos, Facing.of(face));
+        Facing facing = face == null ? null : Facing.of(face);
+        FaceShape faceShape = blockFaceSupplier.getBlockFaceShape(blockAccess, new MCBlockState(state), blockPos, facing);
         return faceShape != null ? faceShape.getInternal() : super.getBlockFaceShape(world, state, pos, face);
     }
 }

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockContent.java
@@ -14,19 +14,22 @@ import com.teamacronymcoders.contenttweaker.api.ctobjects.blockpos.IBlockPos;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockpos.MCBlockPos;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockstate.MCBlockState;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.color.CTColor;
-import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.PushReaction;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.FaceShape;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.Facing;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.itemlist.CTItemList;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.resourcelocation.CTResourceLocation;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.world.MCWorld;
 import com.teamacronymcoders.contenttweaker.api.utils.CTUtils;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockAction;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockColorSupplier;
+import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockFaceSupplier;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.tileentity.TileEntityContent;
 import crafttweaker.mc1120.item.MCItemStack;
 import crafttweaker.mc1120.world.MCBlockAccess;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockFalling;
 import net.minecraft.block.material.EnumPushReaction;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.Entity;
@@ -342,5 +345,24 @@ public class BlockContent extends BlockBase implements IHasBlockColor, IHasItemC
     @Override
     public boolean canSilkHarvest(World world, BlockPos pos, @Nonnull IBlockState state, EntityPlayer player) {
         return blockRepresentation.canSilkHarvest;
+    }
+
+    @Nonnull
+    @Override
+    @Deprecated
+    public BlockFaceShape getBlockFaceShape(IBlockAccess world, IBlockState state, BlockPos pos, EnumFacing face) {
+        IBlockFaceSupplier blockFaceSupplier = blockRepresentation.getBlockFaceSupplier();
+        if (blockFaceSupplier == null) {
+            return super.getBlockFaceShape(world, state, pos, face);
+        }
+        crafttweaker.api.world.IBlockAccess blockAccess = null;
+        if (world instanceof World) {
+            blockAccess = new MCWorld((World) world);
+        } else if (world != null) {
+            blockAccess = new MCBlockAccess(world);
+        }
+        IBlockPos blockPos = pos == null ? null : new MCBlockPos(pos);
+        FaceShape faceShape = blockFaceSupplier.getBlockFaceShape(blockAccess, new MCBlockState(state), blockPos, Facing.of(face));
+        return faceShape != null ? faceShape.getInternal() : super.getBlockFaceShape(world, state, pos, face);
     }
 }

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/blocks/BlockRepresentation.java
@@ -7,11 +7,13 @@ import com.teamacronymcoders.contenttweaker.api.ctobjects.aabb.MCAxisAlignedBB;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockmaterial.BlockMaterialDefinition;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.blockmaterial.IBlockMaterialDefinition;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.color.CTColor;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.FaceShape;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.PushReaction;
 import com.teamacronymcoders.contenttweaker.api.ctobjects.resourcelocation.CTResourceLocation;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockAction;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockColorSupplier;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockDropHandler;
+import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IBlockFaceSupplier;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.functions.IItemColorSupplier;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.items.ICreativeTab;
 import com.teamacronymcoders.contenttweaker.modules.vanilla.resources.creativetab.MCCreativeTab;
@@ -22,6 +24,7 @@ import crafttweaker.annotations.ZenRegister;
 import net.minecraft.block.Block;
 import net.minecraft.block.SoundType;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.state.BlockFaceShape;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.util.BlockRenderLayer;
 import net.minecraft.util.EnumBlockRenderType;
@@ -97,6 +100,8 @@ public class BlockRepresentation implements IRepresentation<Block> {
     public IBlockColorSupplier blockColorSupplier = (state, access, pos, tint) -> CTColor.fromInt(-1);
     @ZenProperty
     public IItemColorSupplier itemColorSupplier = (itemStack, tint) -> CTColor.fromInt(-1);
+    @ZenProperty
+    public IBlockFaceSupplier blockFaceSupplier = (access, state, pos, face) -> FaceShape.solid();
     @ZenProperty
     public CTResourceLocation textureLocation;
     @ZenProperty
@@ -400,6 +405,16 @@ public class BlockRepresentation implements IRepresentation<Block> {
     @ZenMethod
     public void setItemColorSupplier(IItemColorSupplier itemColorSupplier) {
         this.itemColorSupplier = itemColorSupplier;
+    }
+
+    @ZenMethod
+    public void setBlockFaceSupplier(IBlockFaceSupplier blockFaceSupplier) {
+        this.blockFaceSupplier = blockFaceSupplier;
+    }
+
+    @ZenMethod
+    public IBlockFaceSupplier getBlockFaceSupplier() {
+        return this.blockFaceSupplier;
     }
 
     @ZenMethod

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/functions/IBlockFaceSupplier.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/functions/IBlockFaceSupplier.java
@@ -1,0 +1,15 @@
+package com.teamacronymcoders.contenttweaker.modules.vanilla.functions;
+
+import com.teamacronymcoders.contenttweaker.api.ctobjects.blockpos.IBlockPos;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.blockstate.ICTBlockState;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.FaceShape;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.Facing;
+import crafttweaker.annotations.ZenRegister;
+import crafttweaker.api.world.IBlockAccess;
+import stanhebben.zenscript.annotations.ZenClass;
+
+@ZenRegister
+@ZenClass("mods.contenttweaker.IBlockFaceSupplier")
+public interface IBlockFaceSupplier {
+    FaceShape getBlockFaceShape(IBlockAccess access, ICTBlockState state, IBlockPos pos, Facing facing);
+}


### PR DESCRIPTION
At some point I probably will get around to writing docs for this but it does work. Adds support for `getBlockFaceShape` for VanillaFactory blocks, one thing to note is forge has a shortcut so that if full block is true (the default), it ignores the BlockFaceShape for EnumFacing.UP, so things like buttons can still be placed on top even if this new method returns undefined.