### PR TITLE
Allow creation of custom sound events

### DIFF
--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/VanillaFactory.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/VanillaFactory.java
@@ -116,4 +116,14 @@ public class VanillaFactory {
                         .map(CTColor::getInternal)
                         .orElse(null)));
     }
+    
+    @ZenMethod
+    public static void createSoundEvent(String name) {
+        final SoundEventRegistry registry = ContentTweaker.instance.getRegistry(SoundEventRegistry.class, "SOUND_EVENT");
+        final ResourceLocation soundName = new ResourceLocation(ContentTweaker.MOD_ID, name);
+        if (registry.get(soundName) == null) {
+            SoundEvent newSoundEvent = new CustomSoundEvent(soundName);
+            registry.register(soundName, newSoundEvent);
+        }
+    }
 }


### PR DESCRIPTION
This is a simple function in VanillaFactory to add just a custom sound event, without a record attached (and is non-streaming).

This is useful for other mods that take sound events, I specifically made this to be used with Patchouli's open_sound and flip_sound, so they can be customised with ContentTweaker.