### PR TITLE
expose itemInteractionForEntity to created items

### DIFF
--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/functions/IItemInteractionForEntity.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/functions/IItemInteractionForEntity.java
@@ -1,0 +1,15 @@
+package com.teamacronymcoders.contenttweaker.modules.vanilla.functions;
+
+import com.teamacronymcoders.contenttweaker.api.ctobjects.entity.player.ICTPlayer;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.enums.Hand;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.mutableitemstack.IMutableItemStack;
+import com.teamacronymcoders.contenttweaker.api.ctobjects.mutableitemstack.MCMutableItemStack;
+import crafttweaker.api.entity.IEntityLivingBase;
+import crafttweaker.annotations.ZenRegister;
+import stanhebben.zenscript.annotations.ZenClass;
+
+@ZenRegister
+@ZenClass("mods.contenttweaker.IItemInteractionForEntity")
+public interface IItemInteractionForEntity {
+    boolean interactionForEntity(IMutableItemStack itemStack, ICTPlayer player, IEntityLivingBase target, String hand);
+}

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemContent.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemContent.java
@@ -150,6 +150,16 @@ public class ItemContent extends ItemBase implements IHasModel, IHasGeneratedMod
     }
 
     @Override
+    public boolean itemInteractionForEntity(ItemStack stack, EntityPlayer player, EntityLivingBase target, EnumHand hand) {
+        if(itemRepresentation.getItemInteractionForEntity() != null) {
+            return itemRepresentation.getItemInteractionForEntity().interactionForEntity(new MCMutableItemStack(stack),
+                    new CTPlayer(player), EntityHelper.getIEntityLivingBase(target), hand.name()
+            );
+        }
+        return super.itemInteractionForEntity(stack, player, target, hand);
+    }
+
+    @Override
     @Nonnull
     public EnumActionResult onItemUse(EntityPlayer player, World world, BlockPos pos, EnumHand hand, EnumFacing facing,
                                       float hitX, float hitY, float hitZ) {

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemRepresentation.java
@@ -156,11 +156,14 @@ public class ItemRepresentation implements IRepresentation<Item> {
     }
 
     @ZenMethod
-    public IItemInteractionForEntity getItemInteractionForEntity() { return this.itemInteractionForEntity; }
+    public IItemInteractionForEntity getItemInteractionForEntity() {
+        return this.itemInteractionForEntity;
+    }
 
     @ZenMethod
-    public void setItemInteractionForEntity(IItemInteractionForEntity itemInteractionForEntity) { this.itemInteractionForEntity = itemInteractionForEntity; }
-
+    public void setItemInteractionForEntity(IItemInteractionForEntity itemInteractionForEntity) {
+        this.itemInteractionForEntity = itemInteractionForEntity;
+    }
     @ZenMethod
     public String getItemUseAction() {
         return itemUseAction;

--- a/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemRepresentation.java
+++ b/src/main/java/com/teamacronymcoders/contenttweaker/modules/vanilla/items/ItemRepresentation.java
@@ -39,6 +39,8 @@ public class ItemRepresentation implements IRepresentation<Item> {
     @ZenProperty
     public IItemRightClick itemRightClick = null;
     @ZenProperty
+    public IItemInteractionForEntity itemInteractionForEntity = null;
+    @ZenProperty
     public String itemUseAction = EnumAction.NONE.toString();
     @ZenProperty
     public boolean glowing;
@@ -152,6 +154,12 @@ public class ItemRepresentation implements IRepresentation<Item> {
     public void setItemRightClick(IItemRightClick itemRightClick) {
         this.itemRightClick = itemRightClick;
     }
+
+    @ZenMethod
+    public IItemInteractionForEntity getItemInteractionForEntity() { return this.itemInteractionForEntity; }
+
+    @ZenMethod
+    public void setItemInteractionForEntity(IItemInteractionForEntity itemInteractionForEntity) { this.itemInteractionForEntity = itemInteractionForEntity; }
 
     @ZenMethod
     public String getItemUseAction() {


### PR DESCRIPTION
allows created items to specify a function which will be called when the item is used on an entity

example:
```js
#loader contenttweaker

import mods.contenttweaker.VanillaFactory;
import mods.contenttweaker.Item;
import mods.contenttweaker.IItemInteractionForEntity;
import crafttweaker.entity.IEntityLivingBase;

var sheep_remover = VanillaFactory.createItem("sheep_remover");
sheep_remover.itemInteractionForEntity = function(stack, player, target, hand) {
    if target.definition.id == "minecraft:sheep" {
        target.removeFromWorld();
        stack.shrink(1);
        return true;
    }
    return false;
};
sheep_remover.register();
```